### PR TITLE
Implement dynamic sidebar layout based on screen dimensions

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,7 +3,7 @@ import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useState } from "react";
-import { useCombinedMatrix, useDeterminant, useMatrixContext, useSetPref } from "../store/hooks";
+import { useCombinedMatrix, useDeterminant, useMatrixContext, useSetPref, useScreenDimensions } from "../store/hooks";
 import { MatrixTransform, MatrixType } from "../types";
 import { getDefaultValues, getValueLabels, matrixTypes } from "../utils/matrixUtils";
 import MatrixControl, { MatrixGrid } from "./MatrixControl";
@@ -76,6 +76,10 @@ const Sidebar = () => {
   const determinant = useDeterminant();
   const combinedMatrix = useCombinedMatrix();
   const [activeId, setActiveId] = useState<string | null>(null);
+  const { width, height } = useScreenDimensions();
+
+  const isVertical = width > height;
+  const maxSize = Math.min(width, height) * 0.5;
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -127,7 +131,11 @@ const Sidebar = () => {
   const activeMatrix = activeId ? matrices.find(m => m.id === activeId) : null;
 
   return (
-    <div className='h-screen p-4 overflow-y-auto max-w-96 min-w-96 flex flex-col backdrop-blur-lg bg-bg-200/30 border-r border-bg-300' id='sidebar'>
+    <div
+      className={`p-4 overflow-y-auto flex flex-col backdrop-blur-lg bg-bg-200/30 border-bg-300 ${isVertical ? "h-screen max-w-96 min-w-96 border-r" : "w-screen max-h-96 min-h-96 border-t"}`}
+      id='sidebar'
+      style={{ maxWidth: maxSize, maxHeight: maxSize }}
+    >
       <div className='flex-grow'>
         <h1 className='text-2xl font-bold text-primary-600 mb-4'>3D matrix transform visualizer!</h1>
 

--- a/src/index.css
+++ b/src/index.css
@@ -142,3 +142,15 @@
 .transition-spacing {
   transition-property: margin, padding;
 }
+
+/* Add CSS classes for bottom bar layout */
+.bottom-bar {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  max-height: 50%;
+  overflow-y: auto;
+  backdrop-blur-lg;
+  background-color: var(--color-bg-200, rgba(0, 0, 0, 0.3));
+  border-top: 1px solid var(--color-bg-300, rgba(255, 255, 255, 0.3));
+}

--- a/src/index.css
+++ b/src/index.css
@@ -150,7 +150,6 @@
   width: 100%;
   max-height: 50%;
   overflow-y: auto;
-  backdrop-blur-lg;
   background-color: var(--color-bg-200, rgba(0, 0, 0, 0.3));
   border-top: 1px solid var(--color-bg-300, rgba(255, 255, 255, 0.3));
 }

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -60,17 +60,36 @@ export function useCSSVariable(variable: string) {
 
 export const useViewOffset = () => {
   const [viewOffset, setViewOffset] = useState({ offsetX: 0, offsetY: 0 });
+  const { width, height } = useScreenDimensions();
 
   useEffect(() => {
     const handleResize = () => {
-      const sidebarWidth = document.querySelector("#sidebar")?.clientWidth || 0;
-      setViewOffset({ offsetX: -sidebarWidth / 2, offsetY: 0 });
+      const sidebarSize = document.querySelector("#sidebar")?.clientWidth || 0;
+      const isVertical = width > height;
+      const offsetX = isVertical ? -sidebarSize / 2 : 0;
+      const offsetY = isVertical ? 0 : -sidebarSize / 2;
+      setViewOffset({ offsetX, offsetY });
     };
 
     handleResize();
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
-  }, []);
+  }, [width, height]);
 
   return viewOffset;
+};
+
+export const useScreenDimensions = () => {
+  const [dimensions, setDimensions] = useState({ width: window.innerWidth, height: window.innerHeight });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setDimensions({ width: window.innerWidth, height: window.innerHeight });
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return dimensions;
 };


### PR DESCRIPTION
Update the `Sidebar` component to dynamically position itself based on screen dimensions.

* **Sidebar Component:**
  - Import `useScreenDimensions` hook.
  - Add logic to switch between sidebar and bottom bar based on screen dimensions.
  - Ensure the sidebar/bottom bar never takes up more than 50% of the screen size.
  - Adjust CSS classes to support the new layout logic.

* **Hooks:**
  - Add a new hook `useScreenDimensions` to get the current screen dimensions.
  - Use the `useScreenDimensions` hook in `useViewOffset` to adjust the view offset based on screen dimensions.

* **CSS:**
  - Add CSS classes for the bottom bar layout.
  - Ensure the new CSS classes support the dynamic layout logic.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alvesvaren/3d-matrix-visualizer/pull/1?shareId=0b4a4148-fb98-401a-a6d6-787e0df3c383).